### PR TITLE
fix typos in schemas and resolver templates

### DIFF
--- a/phase1/schema.graphql
+++ b/phase1/schema.graphql
@@ -14,7 +14,7 @@ type Address {
   city: String!
   state: String
   country: String!
-  postalcode: String!
+  zip: String!
 }
 
 type Query {

--- a/phase1/template.yaml
+++ b/phase1/template.yaml
@@ -5,7 +5,7 @@ Description: >
 
   Sample project for reInvent 2018 - MOBXXX - 0 to 60 with AWS AppSync -
   Rapid Development Techniques for Mobile APIs
-    
+
 Globals:
   Function:
     Runtime: nodejs8.10
@@ -67,7 +67,7 @@ Resources:
               "address": $hotel.address,
               "image": $hotel.image,
               "phoneNumber": $hotel.phoneNumber,
-              "categrory": $hotel.category,
+              "category": $hotel.category,
               "amenities": $hotel.amenities
             }))
           #end
@@ -75,7 +75,7 @@ Resources:
         #else
           $utils.appendError($ctx.result.body, $ctx.result.statusCode)
         #end
-  
+
   GetHotelQueryResolver:
     Type: AWS::AppSync::Resolver
     DependsOn: ElastiLodgeSchema
@@ -105,7 +105,7 @@ Resources:
             "image": $resp.hotel.image,
             "address": $resp.hotel.address,
             "phoneNumber": $resp.hotel.phoneNumber,
-            "categrory": $resp.hotel.category,
+            "category": $resp.hotel.category,
             "amenities": $resp.hotel.amenities
           })
           $utils.toJson($result)
@@ -162,7 +162,7 @@ Outputs:
   ApiKey:
     Description: "API Key for ElastiLodge API"
     Value: !GetAtt ElastiLodgeApiKey.ApiKey
-  
+
   GraphQLApi:
     Description: "Endpoint for GraphQL"
     Value: !GetAtt ElastiLodgeApi.GraphQLUrl

--- a/phase2/schema.graphql
+++ b/phase2/schema.graphql
@@ -14,7 +14,7 @@ type Address {
   city: String!
   state: String
   country: String!
-  postalcode: String!
+  zip: String!
 }
 
 ## NEW IN PHASE 2 ##

--- a/phase2/schema.graphql
+++ b/phase2/schema.graphql
@@ -21,7 +21,7 @@ type Address {
 type Reservation {
   confirmationNumber: ID!
   hotel: Hotel!
-  guest: String
+  guestId: ID!
   startDate: AWSDate!
   endDate: AWSDate!
   rate: Int!

--- a/phase2/schema.graphql
+++ b/phase2/schema.graphql
@@ -49,7 +49,15 @@ type Mutation {
   deleteReservation(confNum: ID!): Reservation
 }
 
+type Subscription {
+	createReservationEvent(guestId: ID!): Reservation
+		@aws_subscribe(mutations: ["createReservation"])
+	deleteReservationEvent(guestId: ID!): Reservation
+		@aws_subscribe(mutations: ["deleteReservation"])
+}
+
 schema {
-  query: Query
-  mutation: Mutation ## NEW IN PHASE 2 ##
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
 }

--- a/phase2/template.yaml
+++ b/phase2/template.yaml
@@ -170,7 +170,7 @@ Resources:
             "image": $resp.hotel.image,
             "address": $resp.hotel.address,
             "phoneNumber": $resp.hotel.phoneNumber,
-            "categrory": $resp.hotel.category,
+            "category": $resp.hotel.category,
             "amenities": $resp.hotel.amenities
           })
           $utils.toJson($result)

--- a/phase2/template.yaml
+++ b/phase2/template.yaml
@@ -280,6 +280,7 @@ Resources:
               - hotelId
               - confirmationNumber
               - endDate
+              - rate
             ProjectionType: INCLUDE
           ProvisionedThroughput:
             ReadCapacityUnits: 1

--- a/phase2/template.yaml
+++ b/phase2/template.yaml
@@ -5,7 +5,7 @@ Description: >
 
   Sample project for reInvent 2018 - MOBXXX - 0 to 60 with AWS AppSync -
   Rapid Development Techniques for Mobile APIs
-    
+
 Globals:
   Function:
     Runtime: nodejs8.10
@@ -67,7 +67,7 @@ Resources:
               "image": $hotel.image,
               "address": $hotel.address,
               "phoneNumber": $hotel.phoneNumber,
-              "categrory": $hotel.category,
+              "category": $hotel.category,
               "amenities": $hotel.amenities
             }))
           #end
@@ -75,7 +75,7 @@ Resources:
         #else
           $utils.appendError($ctx.result.body, $ctx.result.statusCode)
         #end
-  
+
   GetHotelQueryResolver:
     Type: AWS::AppSync::Resolver
     DependsOn: ElastiLodgeSchema
@@ -105,7 +105,7 @@ Resources:
             "image": $resp.hotel.image,
             "address": $resp.hotel.address,
             "phoneNumber": $resp.hotel.phoneNumber,
-            "categrory": $resp.hotel.category,
+            "category": $resp.hotel.category,
             "amenities": $resp.hotel.amenities
           })
           $utils.toJson($result)
@@ -220,7 +220,7 @@ Resources:
         }
       ResponseMappingTemplate: |
         $util.toJson($ctx.result)
-  
+
   #
   # GraphQL Data Sources
   #
@@ -352,7 +352,7 @@ Outputs:
   ApiKey:
     Description: "API Key for ElastiLodge API"
     Value: !GetAtt ElastiLodgeApiKey.ApiKey
-  
+
   GraphQLApi:
     Description: "Endpoint for GraphQL"
     Value: !GetAtt ElastiLodgeApi.GraphQLUrl

--- a/phase3/schema.graphql
+++ b/phase3/schema.graphql
@@ -29,7 +29,7 @@ type Rate {
 type Reservation {
   confirmationNumber: ID!
   hotel: Hotel!
-  guest: String
+  guestId: ID!
   startDate: AWSDate!
   endDate: AWSDate!
   rate: Int!

--- a/phase3/schema.graphql
+++ b/phase3/schema.graphql
@@ -15,7 +15,7 @@ type Address {
   city: String!
   state: String
   country: String!
-  postalcode: String!
+  zip: String!
 }
 
 ## NEW IN PHASE 3 ##

--- a/phase3/schema.graphql
+++ b/phase3/schema.graphql
@@ -55,7 +55,15 @@ type Mutation {
   deleteReservation(confNum: ID!): Reservation
 }
 
+type Subscription {
+	createReservationEvent(guestId: ID!): Reservation
+		@aws_subscribe(mutations: ["createReservation"])
+	deleteReservationEvent(guestId: ID!): Reservation
+		@aws_subscribe(mutations: ["deleteReservation"])
+}
+
 schema {
-  query: Query
-  mutation: Mutation
+	query: Query
+	mutation: Mutation
+	subscription: Subscription
 }

--- a/phase3/template.yaml
+++ b/phase3/template.yaml
@@ -5,7 +5,7 @@ Description: >
 
   Sample project for reInvent 2018 - MOBXXX - 0 to 60 with AWS AppSync -
   Rapid Development Techniques for Mobile APIs
-    
+
 Globals:
   Function:
     Runtime: nodejs8.10
@@ -67,7 +67,7 @@ Resources:
               "image": $hotel.image,
               "address": $hotel.address,
               "phoneNumber": $hotel.phoneNumber,
-              "categrory": $hotel.category,
+              "category": $hotel.category,
               "amenities": $hotel.amenities
             }))
           #end
@@ -75,7 +75,7 @@ Resources:
         #else
           $utils.appendError($ctx.result.body, $ctx.result.statusCode)
         #end
-  
+
   GetHotelQueryResolver:
     Type: AWS::AppSync::Resolver
     DependsOn: ElastiLodgeSchema
@@ -105,7 +105,7 @@ Resources:
             "image": $resp.hotel.image,
             "address": $resp.hotel.address,
             "phoneNumber": $resp.hotel.phoneNumber,
-            "categrory": $resp.hotel.category,
+            "category": $resp.hotel.category,
             "amenities": $resp.hotel.amenities
           })
           $utils.toJson($result)
@@ -243,7 +243,7 @@ Resources:
         }
       ResponseMappingTemplate: |
         $util.toJson($ctx.result)
-  
+
   #
   # GraphQL Data Sources
   #
@@ -390,7 +390,7 @@ Outputs:
   ApiKey:
     Description: "API Key for ElastiLodge API"
     Value: !GetAtt ElastiLodgeApiKey.ApiKey
-  
+
   GraphQLApi:
     Description: "Endpoint for GraphQL"
     Value: !GetAtt ElastiLodgeApi.GraphQLUrl

--- a/phase3/template.yaml
+++ b/phase3/template.yaml
@@ -195,7 +195,7 @@ Resources:
             "image": $resp.hotel.image,
             "address": $resp.hotel.address,
             "phoneNumber": $resp.hotel.phoneNumber,
-            "categrory": $resp.hotel.category,
+            "category": $resp.hotel.category,
             "amenities": $resp.hotel.amenities
           })
           $utils.toJson($result)
@@ -303,6 +303,7 @@ Resources:
               - hotelId
               - confirmationNumber
               - endDate
+              - rate
             ProjectionType: INCLUDE
           ProvisionedThroughput:
             ReadCapacityUnits: 1


### PR DESCRIPTION
Minor typos that went undetected while testing on the console.  They caused the mobile client app to fail.